### PR TITLE
[Fix] 테스트시 LazyInitialException

### DIFF
--- a/src/test/java/com/prography/yakgwa/domain/meet/impl/MeetReaderTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/meet/impl/MeetReaderTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 
@@ -34,6 +35,7 @@ class MeetReaderTest {
         meetThemeJpaRepository.deleteAll();
     }
 
+    @Transactional
     @Test
     void 모임조회Test() {
         // given
@@ -57,7 +59,6 @@ class MeetReaderTest {
                 () -> assertEquals(saveMeet.getPeriod().getStartDate(), compareMeet.getPeriod().getStartDate()),
                 () -> assertEquals(saveMeet.getPeriod().getEndDate(), compareMeet.getPeriod().getEndDate()),
                 () -> assertEquals(saveMeet.getMeetTheme().getName(), compareMeet.getMeetTheme().getName()));
-
     }
 
     @Test


### PR DESCRIPTION
테스트코드의 경우 트랜잭션이 닫혀서 지연로딩이 안되는 경우 LazyException발생하여 트랜잭션 붙혀서 해결

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #25 

---
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 트랜잭션이 테코에서 닫혀서 지연로딩 안되서 발생하는 에러 수정(@Transactional붙혀줌)

### 스크린샷 (선택)


---