### PR TITLE
[refactor] meetWrite Impl로직 수정

### DIFF
--- a/src/main/java/com/prography/yakgwa/domain/meet/impl/MeetWriter.java
+++ b/src/main/java/com/prography/yakgwa/domain/meet/impl/MeetWriter.java
@@ -5,6 +5,10 @@ import com.prography.yakgwa.domain.meet.entity.MeetTheme;
 import com.prography.yakgwa.domain.meet.entity.embed.VotePeriod;
 import com.prography.yakgwa.domain.meet.impl.dto.MeetWriteDto;
 import com.prography.yakgwa.domain.meet.repository.MeetJpaRepository;
+import com.prography.yakgwa.domain.vote.impl.PlaceVoteWriter;
+import com.prography.yakgwa.domain.vote.impl.TimeVoteWriter;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmPlaceDto;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmTimeDto;
 import com.prography.yakgwa.global.meta.ImplService;
 import lombok.RequiredArgsConstructor;
 
@@ -13,8 +17,10 @@ import lombok.RequiredArgsConstructor;
 public class MeetWriter {
     private final MeetJpaRepository meetJpaRepository;
     private final MeetThemeReader meetThemeReader;
+    private final PlaceVoteWriter placeVoteWriter;
+    private final TimeVoteWriter timeVoteWriter;
 
-    public Meet write(MeetWriteDto writeDto) {
+    public Meet write(MeetWriteDto writeDto, ConfirmPlaceDto confirmPlaceDto, ConfirmTimeDto confirmTimeDto) {
         if ((writeDto.getMeetTime() == null && writeDto.getPeriod() == null) ||
                 (writeDto.getMeetTime() != null && writeDto.getPeriod() != null)) {
             throw new RuntimeException("시간은 투표 또는 확정중 한가지만 가능합니다!");
@@ -36,7 +42,10 @@ public class MeetWriter {
                 .validInviteHour(24)
                 .build();
 
-        return meetJpaRepository.save(meet);
+        Meet saveMeet = meetJpaRepository.save(meet);
+        placeVoteWriter.decideConfirmAndWrite(saveMeet,confirmPlaceDto);
+        timeVoteWriter.confirmAndWrite(saveMeet, confirmTimeDto);
+        return saveMeet;
     }
 
 }

--- a/src/main/java/com/prography/yakgwa/domain/meet/service/MeetService.java
+++ b/src/main/java/com/prography/yakgwa/domain/meet/service/MeetService.java
@@ -31,8 +31,6 @@ public class MeetService {
     private final MeetWriter meetWriter;
     private final UserReader userReader;
     private final ParticipantWriter participantWriter;
-    private final PlaceVoteWriter placeVoteWriter;
-    private final TimeVoteWriter timeVoteWriter;
     private final MeetReader meetReader;
     private final ParticipantReader participantReader;
     private final MeetStatusJudger meetStatusJudger;
@@ -47,10 +45,8 @@ public class MeetService {
     @Transactional
     public Meet create(MeetCreateRequestDto requestDto) {
         User user = userReader.read(requestDto.getCreatorId());
-        Meet meet = meetWriter.write(MeetWriteDto.of(requestDto));
+        Meet meet = meetWriter.write(requestDto.toMeetWriteDto(),requestDto.toConfirmPlaceDto(),requestDto.toConfirmTimeDto());
         participantWriter.registLeader(meet, user);
-        placeVoteWriter.confirmAndWrite(meet,requestDto.isConfirmPlace(),requestDto.getPlaceInfo());
-        timeVoteWriter.confirmAndWrite(meet, requestDto.getMeetTime());
         return meet;
     }
 

--- a/src/main/java/com/prography/yakgwa/domain/meet/service/req/MeetCreateRequestDto.java
+++ b/src/main/java/com/prography/yakgwa/domain/meet/service/req/MeetCreateRequestDto.java
@@ -1,7 +1,11 @@
 package com.prography.yakgwa.domain.meet.service.req;
 
+import com.prography.yakgwa.domain.meet.entity.embed.VotePeriod;
+import com.prography.yakgwa.domain.meet.impl.dto.MeetWriteDto;
 import com.prography.yakgwa.domain.meet.service.dto.VoteDateDto;
 import com.prography.yakgwa.domain.place.entity.dto.PlaceInfoDto;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmPlaceDto;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmTimeDto;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -26,4 +30,33 @@ public class MeetCreateRequestDto {
 
     //해당값이 있다면 확정,null이면 투표
     private LocalDateTime meetTime;
+
+    public ConfirmPlaceDto toConfirmPlaceDto(){
+        return ConfirmPlaceDto.builder()
+                .confirmPlace(confirmPlace)
+                .placeInfo(placeInfo)
+                .build();
+    }
+    public ConfirmTimeDto toConfirmTimeDto(){
+        return ConfirmTimeDto.builder()
+                .meetTime(meetTime)
+                .build();
+    }
+    public MeetWriteDto toMeetWriteDto(){
+        VotePeriod votePeriod = null;
+        if (voteDateDto != null) {
+            votePeriod = VotePeriod.builder()
+                    .startDate(voteDateDto.getStartVoteDate())
+                    .endDate(voteDateDto.getEndVoteDate())
+                    .build();
+        }
+        return MeetWriteDto.builder()
+                .period(votePeriod)
+                .meetTime(meetTime)
+                .meetThemeId(meetThemeId)
+                .build();
+    }
+
+
+
 }

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/PlaceVoteWriter.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/PlaceVoteWriter.java
@@ -8,6 +8,7 @@ import com.prography.yakgwa.domain.place.impl.PlaceWriter;
 import com.prography.yakgwa.domain.user.entity.User;
 import com.prography.yakgwa.domain.vote.entity.place.PlaceSlot;
 import com.prography.yakgwa.domain.vote.entity.place.PlaceVote;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmPlaceDto;
 import com.prography.yakgwa.domain.vote.repository.PlaceVoteJpaRepository;
 import com.prography.yakgwa.global.meta.ImplService;
 import lombok.RequiredArgsConstructor;
@@ -36,10 +37,14 @@ public class PlaceVoteWriter {
         return placeVoteJpaRepository.saveAll(placeVotes);
     }
 
-    public void confirmAndWrite(Meet meet, boolean isConfirmPlace, List<PlaceInfoDto> placeInfo) {
+    public void decideConfirmAndWrite(Meet meet, ConfirmPlaceDto confirmPlaceDto) {
+        List<PlaceInfoDto> placeInfo = confirmPlaceDto.getPlaceInfo();
+        boolean isConfirmPlace = confirmPlaceDto.isConfirmPlace();
+
         if (isConfirmPlace && placeInfo.size() != 1) {
             throw new RuntimeException("확정된 장소는 1개이어야 합니다");
         }
+
         List<Place> placeList = placeInfo.stream()
                 .map(placeInfoDto -> placeReader.readByMapxAndMapy(placeInfoDto.getMapx(), placeInfoDto.getMapy())
                         .orElseGet(() -> placeWriter.write(placeInfoDto.toEntity())))

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/TimeVoteWriter.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/TimeVoteWriter.java
@@ -5,6 +5,7 @@ import com.prography.yakgwa.domain.user.entity.User;
 import com.prography.yakgwa.domain.vote.entity.place.PlaceVote;
 import com.prography.yakgwa.domain.vote.entity.time.TimeSlot;
 import com.prography.yakgwa.domain.vote.entity.time.TimeVote;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmTimeDto;
 import com.prography.yakgwa.domain.vote.repository.TimeVoteJpaRepository;
 import com.prography.yakgwa.global.meta.ImplService;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +21,12 @@ public class TimeVoteWriter {
     private final TimeVoteJpaRepository timeVoteJpaRepository;
     private final TimeSlotWriter timeSlotWriter;
 
-    public void confirmAndWrite(Meet meet, LocalDateTime meetTime) {
-        if (meetTime == null) { //해당 값이 있다면 확정,null이면 투표
+    public void confirmAndWrite(Meet meet, ConfirmTimeDto confirmTimeDto) {
+        if (confirmTimeDto.getMeetTime() == null) { //해당 값이 있다면 확정,null이면 투표
             return;
         }
         TimeSlot timeSlot = TimeSlot.builder()
-                .meet(meet).time(meetTime).confirm(Boolean.TRUE)
+                .meet(meet).time(confirmTimeDto.getMeetTime()).confirm(Boolean.TRUE)
                 .build();
         timeSlotWriter.write(timeSlot);
     }

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/dto/ConfirmPlaceDto.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/dto/ConfirmPlaceDto.java
@@ -1,0 +1,16 @@
+package com.prography.yakgwa.domain.vote.impl.dto;
+
+import com.prography.yakgwa.domain.place.entity.dto.PlaceInfoDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+public class ConfirmPlaceDto {
+    private boolean confirmPlace;
+
+    //null이라면 장소투표로
+    private List<PlaceInfoDto> placeInfo;
+}

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/dto/ConfirmTimeDto.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/dto/ConfirmTimeDto.java
@@ -1,0 +1,13 @@
+package com.prography.yakgwa.domain.vote.impl.dto;
+
+import com.prography.yakgwa.domain.meet.service.dto.VoteDateDto;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+public class ConfirmTimeDto {
+    private LocalDateTime meetTime;
+}

--- a/src/test/java/com/prography/yakgwa/domain/meet/impl/MeetWriterTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/meet/impl/MeetWriterTest.java
@@ -6,9 +6,15 @@ import com.prography.yakgwa.domain.meet.entity.embed.VotePeriod;
 import com.prography.yakgwa.domain.meet.impl.dto.MeetWriteDto;
 import com.prography.yakgwa.domain.meet.repository.MeetJpaRepository;
 import com.prography.yakgwa.domain.meet.repository.MeetThemeJpaRepository;
-import org.assertj.core.api.Assertions;
+import com.prography.yakgwa.domain.place.entity.dto.PlaceInfoDto;
+import com.prography.yakgwa.domain.place.repository.PlaceJpaRepository;
+import com.prography.yakgwa.domain.vote.entity.place.PlaceSlot;
+import com.prography.yakgwa.domain.vote.entity.time.TimeSlot;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmPlaceDto;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmTimeDto;
+import com.prography.yakgwa.domain.vote.repository.PlaceSlotJpaRepository;
+import com.prography.yakgwa.domain.vote.repository.TimeSlotJpaRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -16,6 +22,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,11 +37,19 @@ class MeetWriterTest {
     MeetJpaRepository meetJpaRepository;
     @Autowired
     MeetWriter meetWriter;
-
+    @Autowired
+    private TimeSlotJpaRepository timeSlotJpaRepository;
+    @Autowired
+    private PlaceSlotJpaRepository placeSlotJpaRepository;
+    @Autowired
+    PlaceJpaRepository placeJpaRepository;
     @AfterEach
     void init() {
+        timeSlotJpaRepository.deleteAll();
+        placeSlotJpaRepository.deleteAll();
         meetJpaRepository.deleteAll();
         meetThemeJpaRepository.deleteAll();
+        placeJpaRepository.deleteAll();
     }
 
     @Test
@@ -47,22 +62,39 @@ class MeetWriterTest {
         String title = "test";
         MeetWriteDto writeDto = MeetWriteDto.builder()
                 .meetTime(null)
-                .period(new VotePeriod(from,to))
+                .period(new VotePeriod(from, to))
                 .title(title)
                 .meetThemeId(saveMeetTheme.getId())
                 .build();
+
+        PlaceInfoDto placeInfoDto1 = PlaceInfoDto.builder().title("title").build();
+        PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder().title("title").build();
+
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder()
+                .placeInfo(List.of(placeInfoDto1, placeInfoDto2)).confirmPlace(false)
+                .build();
+
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder()
+                .meetTime(null)
+                .build();
+
         // when
         System.out.println("=====Logic Start=====");
 
-        Meet meet = meetWriter.write(writeDto);
+        Meet meet = meetWriter.write(writeDto, confirmPlaceDto, confirmTimeDto);
 
         System.out.println("=====Logic End=====");
         // then
+        List<TimeSlot> byMeetId = timeSlotJpaRepository.findByMeetId(meet.getId());
+        List<PlaceSlot> placeSlots = placeSlotJpaRepository.findAllByMeetId(meet.getId());
+
         assertAll(() -> assertThat(meet.getTitle()).isEqualTo(title),
                 () -> assertThat(meet.getValidInviteHour()).isEqualTo(24),
                 () -> assertThat(meet.getMeetTheme().getName()).isEqualTo(meetTheme.getName()),
-                ()-> assertThat(meet.getPeriod().getEndDate()).isEqualTo(to),
-                ()-> assertThat(meet.getPeriod().getStartDate()).isEqualTo(from));
+                () -> assertThat(meet.getPeriod().getEndDate()).isEqualTo(to),
+                () -> assertThat(meet.getPeriod().getStartDate()).isEqualTo(from),
+                () -> assertThat(byMeetId.size()).isZero(),
+                () -> assertThat(placeSlots.size()).isEqualTo(2));
     }
 
     @Test
@@ -79,17 +111,35 @@ class MeetWriterTest {
                 .meetThemeId(savevMeetTheme.getId())
                 .build();
 
+        PlaceInfoDto placeInfoDto1 = PlaceInfoDto.builder().title("title").build();
+        PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder().title("title").build();
+
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder()
+                .placeInfo(List.of(placeInfoDto1, placeInfoDto2)).confirmPlace(false)
+                .build();
+
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder()
+                .meetTime(LocalDateTime.now())
+                .build();
+
         // when
         System.out.println("=====Logic Start=====");
 
-        Meet meet = meetWriter.write(writeDto);
+        Meet meet = meetWriter.write(writeDto, confirmPlaceDto, confirmTimeDto);
 
         System.out.println("=====Logic End=====");
         // then
+        List<TimeSlot> timeSlots = timeSlotJpaRepository.findByMeetId(meet.getId());
+        List<TimeSlot> confirmTimeSlot = timeSlots.stream().filter(TimeSlot::isConfirm).toList();
+        List<PlaceSlot> placeSlots = placeSlotJpaRepository.findAllByMeetId(meet.getId());
+
         assertAll(() -> assertThat(meet.getTitle()).isEqualTo(title),
                 () -> assertThat(meet.getValidInviteHour()).isEqualTo(24),
                 () -> assertThat(meet.getMeetTheme().getName()).isEqualTo(meetTheme.getName()),
-                ()-> assertThat(meet.getPeriod()).isNull());
+                () -> assertThat(meet.getPeriod()).isNull(),
+                () -> assertThat(timeSlots.size()).isEqualTo(1),
+                () -> assertThat(confirmTimeSlot.size()).isEqualTo(1),
+                ()-> assertThat(placeSlots.size()).isEqualTo(2));
     }
 
     @Test
@@ -105,10 +155,23 @@ class MeetWriterTest {
                 .meetThemeId(meetTheme.getId())
                 .build();
 
+
+        PlaceInfoDto placeInfoDto1 = PlaceInfoDto.builder().title("title").build();
+        PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder().title("title").build();
+
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder()
+                .placeInfo(List.of(placeInfoDto1, placeInfoDto2)).confirmPlace(false)
+                .build();
+
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder()
+                .meetTime(null)
+                .build();
+
+
         // when
         System.out.println("=====Logic Start=====");
 
-        assertThrows(RuntimeException.class,()->meetWriter.write(writeDto));
+        assertThrows(RuntimeException.class, () -> meetWriter.write(writeDto, confirmPlaceDto, confirmTimeDto));
 
         System.out.println("=====Logic End=====");
         // then
@@ -125,15 +188,28 @@ class MeetWriterTest {
         String title = "test";
         MeetWriteDto writeDto = MeetWriteDto.builder()
                 .meetTime(time)
-                .period(new VotePeriod(from,to))
+                .period(new VotePeriod(from, to))
                 .title(title)
                 .meetThemeId(meetTheme.getId())
                 .build();
 
+
+        PlaceInfoDto placeInfoDto1 = PlaceInfoDto.builder().title("title").build();
+        PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder().title("title").build();
+
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder()
+                .placeInfo(List.of(placeInfoDto1, placeInfoDto2)).confirmPlace(false)
+                .build();
+
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder()
+                .meetTime(null)
+                .build();
+
+
         // when
         System.out.println("=====Logic Start=====");
 
-        assertThrows(RuntimeException.class,()->meetWriter.write(writeDto));
+        assertThrows(RuntimeException.class, () -> meetWriter.write(writeDto, confirmPlaceDto, confirmTimeDto));
 
         System.out.println("=====Logic End=====");
         // then

--- a/src/test/java/com/prography/yakgwa/domain/vote/impl/PlaceVoteWriterTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/vote/impl/PlaceVoteWriterTest.java
@@ -12,10 +12,9 @@ import com.prography.yakgwa.domain.user.entity.AuthType;
 import com.prography.yakgwa.domain.user.entity.User;
 import com.prography.yakgwa.domain.user.repository.UserJpaRepository;
 import com.prography.yakgwa.domain.vote.entity.place.PlaceSlot;
-import com.prography.yakgwa.domain.vote.entity.place.PlaceVote;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmPlaceDto;
 import com.prography.yakgwa.domain.vote.repository.PlaceSlotJpaRepository;
 import com.prography.yakgwa.domain.vote.repository.PlaceVoteJpaRepository;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,7 +25,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import static java.time.LocalDate.now;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -80,11 +78,11 @@ class PlaceVoteWriterTest {
         PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder()
                 .mapx("1232").mapy("3212").link("link2").address("address2").roadAddress("roadAddress2").category("category2").description("description2").title("title2").telephone("telephone2")
                 .build();
-
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder().confirmPlace(false).placeInfo(List.of(placeInfoDto1, placeInfoDto2)).build();
         // when
         System.out.println("=====Logic Start=====");
 
-        placeVoteWriter.confirmAndWrite(saveMeet, false, List.of(placeInfoDto1, placeInfoDto2));
+        placeVoteWriter.decideConfirmAndWrite(saveMeet, confirmPlaceDto);
 
         System.out.println("=====Logic End=====");
         // then
@@ -96,7 +94,6 @@ class PlaceVoteWriterTest {
                         .filter(placeSlot -> placeSlot.getConfirm().equals(Boolean.FALSE))
                         .toList()
                         .size()));
-
     }
 
     @Test
@@ -117,11 +114,12 @@ class PlaceVoteWriterTest {
                 .build();
 
         placeJpaRepository.save(placeInfoDto.toEntity());
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder().confirmPlace(false).placeInfo(List.of(placeInfoDto)).build();
 
         // when
         System.out.println("=====Logic Start=====");
 
-        placeVoteWriter.confirmAndWrite(saveMeet, false, List.of(placeInfoDto));
+        placeVoteWriter.decideConfirmAndWrite(saveMeet, confirmPlaceDto);
 
         System.out.println("=====Logic End=====");
         // then
@@ -152,11 +150,12 @@ class PlaceVoteWriterTest {
         PlaceInfoDto placeInfoDto1 = PlaceInfoDto.builder()
                 .mapx("321").mapy("123").link("link1").address("address1").roadAddress("roadAddress1").category("category1").description("description1").title("title1").telephone("telephone1")
                 .build();
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder().confirmPlace(true).placeInfo(List.of(placeInfoDto1)).build();
 
         // when
         System.out.println("=====Logic Start=====");
 
-        placeVoteWriter.confirmAndWrite(saveMeet, true, List.of(placeInfoDto1));
+        placeVoteWriter.decideConfirmAndWrite(saveMeet, confirmPlaceDto);
 
         System.out.println("=====Logic End=====");
         // then
@@ -193,11 +192,12 @@ class PlaceVoteWriterTest {
                 .build();
 
         placeJpaRepository.save(placeInfoDto1.toEntity());
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder().confirmPlace(true).placeInfo(List.of(placeInfoDto1)).build();
 
         // when
         System.out.println("=====Logic Start=====");
 
-        placeVoteWriter.confirmAndWrite(saveMeet, true, List.of(placeInfoDto1));
+        placeVoteWriter.decideConfirmAndWrite(saveMeet, confirmPlaceDto);
 
         System.out.println("=====Logic End=====");
         // then
@@ -236,12 +236,13 @@ class PlaceVoteWriterTest {
         PlaceInfoDto placeInfoDto2 = PlaceInfoDto.builder()
                 .mapx("321").mapy("123").link("link1").address("address1").roadAddress("roadAddress1").category("category1").description("description1").title("title1").telephone("telephone1")
                 .build();
+        ConfirmPlaceDto confirmPlaceDto = ConfirmPlaceDto.builder().confirmPlace(true).placeInfo(List.of(placeInfoDto1, placeInfoDto2)).build();
 
         // when
         // then
         System.out.println("=====Logic Start=====");
 
-        assertThrows(RuntimeException.class, () -> placeVoteWriter.confirmAndWrite(saveMeet, true, List.of(placeInfoDto1, placeInfoDto2)));
+        assertThrows(RuntimeException.class, () -> placeVoteWriter.decideConfirmAndWrite(saveMeet, confirmPlaceDto));
 
         System.out.println("=====Logic End=====");
     }

--- a/src/test/java/com/prography/yakgwa/domain/vote/impl/TimeVoteWriterTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/vote/impl/TimeVoteWriterTest.java
@@ -10,6 +10,7 @@ import com.prography.yakgwa.domain.user.entity.User;
 import com.prography.yakgwa.domain.user.repository.UserJpaRepository;
 import com.prography.yakgwa.domain.vote.entity.time.TimeSlot;
 import com.prography.yakgwa.domain.vote.entity.time.TimeVote;
+import com.prography.yakgwa.domain.vote.impl.dto.ConfirmTimeDto;
 import com.prography.yakgwa.domain.vote.repository.TimeSlotJpaRepository;
 import com.prography.yakgwa.domain.vote.repository.TimeVoteJpaRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -65,10 +66,12 @@ class TimeVoteWriterTest {
 
         String formattedDate = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
         LocalDateTime confirmTime = LocalDateTime.parse(formattedDate + "T00:00:00");
+
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder().meetTime(confirmTime).build();
         // when
         System.out.println("=====Logic Start=====");
 
-        timeVoteWriter.confirmAndWrite(saveMeet, confirmTime);
+        timeVoteWriter.confirmAndWrite(saveMeet, confirmTimeDto);
 
         System.out.println("=====Logic End=====");
         // then
@@ -90,10 +93,11 @@ class TimeVoteWriterTest {
 
         Meet saveMeet = createAndSaveMeet(1, saveTheme);
 
+        ConfirmTimeDto confirmTimeDto = ConfirmTimeDto.builder().meetTime(null).build();
         // when
         System.out.println("=====Logic Start=====");
 
-        timeVoteWriter.confirmAndWrite(saveMeet, null);
+        timeVoteWriter.confirmAndWrite(saveMeet, confirmTimeDto);
 
         System.out.println("=====Logic End=====");
         // then


### PR DESCRIPTION
모임생성시 무조건적으로 후보지생성 필요하기때문에 후보지 생성메서드를 모임생성 메서드 내부로 이동

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- 

---
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- meetService의 모임과 후보지 로직 위치 변경

### 스크린샷 (선택)


---