### PR TITLE
[Fix] 투표 조회시 데이터 정합 문제수정

### DIFF
--- a/src/main/java/com/prography/yakgwa/domain/meet/service/MeetService.java
+++ b/src/main/java/com/prography/yakgwa/domain/meet/service/MeetService.java
@@ -5,7 +5,6 @@ import com.prography.yakgwa.domain.meet.entity.MeetStatus;
 import com.prography.yakgwa.domain.meet.impl.MeetReader;
 import com.prography.yakgwa.domain.meet.impl.MeetStatusJudger;
 import com.prography.yakgwa.domain.meet.impl.MeetWriter;
-import com.prography.yakgwa.domain.meet.impl.dto.MeetWriteDto;
 import com.prography.yakgwa.domain.meet.service.req.MeetCreateRequestDto;
 import com.prography.yakgwa.domain.meet.service.req.MeetWithVoteAndStatus;
 import com.prography.yakgwa.domain.meet.service.res.MeetInfoWithParticipant;
@@ -17,6 +16,7 @@ import com.prography.yakgwa.domain.user.impl.UserReader;
 import com.prography.yakgwa.domain.vote.entity.place.PlaceSlot;
 import com.prography.yakgwa.domain.vote.entity.time.TimeSlot;
 import com.prography.yakgwa.domain.vote.impl.*;
+import com.prography.yakgwa.global.format.exception.param.DataIntegrateException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,14 +38,14 @@ public class MeetService {
     private final TimeSlotReader timeSlotReader;
 
     /**
-    * Todo
-    * 요청 dto에서 투표확정시간과 투표가능시간을 둘다 받는데 이것을 모임 생성할때
+     * Todo
+     * 요청 dto에서 투표확정시간과 투표가능시간을 둘다 받는데 이것을 모임 생성할때
      * 해당 값들을 검증하는게 맞을까? 둘다 null이거나 둘다 값이 들어가있는경우 예외처리해야하는데 현재는 meetWriter.write에서 처리하고 있음
-    */
+     */
     @Transactional
     public Meet create(MeetCreateRequestDto requestDto) {
         User user = userReader.read(requestDto.getCreatorId());
-        Meet meet = meetWriter.write(requestDto.toMeetWriteDto(),requestDto.toConfirmPlaceDto(),requestDto.toConfirmTimeDto());
+        Meet meet = meetWriter.write(requestDto.toMeetWriteDto(), requestDto.toConfirmPlaceDto(), requestDto.toConfirmTimeDto());
         participantWriter.registLeader(meet, user);
         return meet;
     }
@@ -64,8 +64,20 @@ public class MeetService {
         for (Participant participant : participants) {
             Meet meet = participant.getMeet();
             MeetStatus meetStatus = meetStatusJudger.judge(meet, user);
-            PlaceSlot placeSlot=placeSlotReader.readConfirmOrNullByMeetId(meet.getId());;
-            TimeSlot timeSlot = timeSlotReader.readConfirmOrNullByMeetId(meet.getId());
+            List<PlaceSlot> placeSlots = placeSlotReader.readAllConfirmByMeetId(meet.getId());
+            List<TimeSlot> timeSlots = timeSlotReader.readAllConfirmByMeetId(meet.getId());
+            TimeSlot timeSlot = null;
+            PlaceSlot placeSlot = null;
+            if(placeSlots.size()>1){
+                throw new DataIntegrateException();
+            }else if (placeSlots.size()==1){
+                placeSlot = placeSlots.stream().findFirst().get();
+            }
+            if(timeSlots.size()>1){
+                throw new DataIntegrateException();
+            }else if(timeSlots.size()==1){
+                timeSlot = timeSlots.stream().findFirst().get();
+            }
             list.add(MeetWithVoteAndStatus.builder()
                     .meet(meet)
                     .timeSlot(timeSlot)

--- a/src/main/java/com/prography/yakgwa/domain/vote/controller/VoteController.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/controller/VoteController.java
@@ -59,17 +59,17 @@ public class VoteController implements VoteApi {
 
     @PatchMapping("/meets/{meetId}/places/confirm")
     public SuccessResponse<String> confirmPlaceInMeet(@AuthenticationPrincipal CustomUserDetail user,
-                                                      @PathVariable("meetId") Long meetId,
-                                                      @RequestBody @Valid ConfirmPlaceVoteInMeetRequest request) {
-        voteService.confirmPlace(user.getUserId(), meetId, request.getConfirmPlaceSlotId());
-        return SuccessResponse.ok("장소가 확정되었습니다");
-    }
+                                                          @PathVariable("meetId") Long meetId,
+                                                          @RequestBody @Valid ConfirmPlaceVoteInMeetRequest request) {
+            voteService.confirmPlace(user.getUserId(), meetId, request.getConfirmPlaceSlotId());
+            return SuccessResponse.ok("장소가 확정되었습니다");
+        }
 
-    @PatchMapping("/meets/{meetId}/times/confirm")
-    public SuccessResponse<String> confirmTimeInMeet(@AuthenticationPrincipal CustomUserDetail user,
-                                                     @PathVariable("meetId") Long meetId,
-                                                     @RequestBody @Valid ConfirmTimeVoteInMeetRequest request) {
-        voteService.confirmTime(user.getUserId(), meetId, request.getConfirmTimeSlotId());
-        return SuccessResponse.ok("시간이 확정되었습니다");
+        @PatchMapping("/meets/{meetId}/times/confirm")
+        public SuccessResponse<String> confirmTimeInMeet(@AuthenticationPrincipal CustomUserDetail user,
+                                                         @PathVariable("meetId") Long meetId,
+                                                         @RequestBody @Valid ConfirmTimeVoteInMeetRequest request) {
+            voteService.confirmTime(user.getUserId(), meetId, request.getConfirmTimeSlotId());
+            return SuccessResponse.ok("시간이 확정되었습니다");
     }
 }

--- a/src/main/java/com/prography/yakgwa/domain/vote/controller/req/EnableTimeRequest.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/controller/req/EnableTimeRequest.java
@@ -4,11 +4,21 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.prography.yakgwa.domain.vote.service.req.EnableTimeRequestDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Schema(description = "모임 참여가 가능한 시간<br>" +
         "취소한 정보외의 가능하다 표시한 모든 시간 보내주세요!<br>" +
         "이전에 이미 등록한 시간도 보내주세요!")
@@ -19,6 +29,9 @@ public class EnableTimeRequest {
     @NotNull(message = "참여가능한 시간을 보내주세요.")
     private List<EnableTImeVote> enableTImes;
 
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     @Getter
     @Schema(name = "EnableTimeRequest-EnableTImeVote")
     private static class EnableTImeVote {
@@ -28,7 +41,14 @@ public class EnableTimeRequest {
     }
 
     public EnableTimeRequestDto toRequestDto() {
-        List<LocalDateTime> enableTimes = this.enableTImes.stream().map(EnableTImeVote::getEnableTime).toList();
+        Set<LocalDateTime> enableTimes = this.enableTImes.stream().map(EnableTImeVote::getEnableTime).collect(Collectors.toSet());
         return EnableTimeRequestDto.builder().enableTimes(enableTimes).build();
+    }
+
+    public static EnableTimeRequest of(List<LocalDateTime> times) {
+        return EnableTimeRequest.builder().enableTImes(times.stream()
+                        .map(time -> EnableTImeVote.builder().enableTime(time).build())
+                        .collect(toList()))
+                .build();
     }
 }

--- a/src/main/java/com/prography/yakgwa/domain/vote/controller/req/VotePlaceRequest.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/controller/req/VotePlaceRequest.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
 import java.util.List;
+import java.util.Set;
 
 @Schema(description = "투표한 장소의 아이디값<br>" +
         "이전에 투표했던 값들이더라도 전부 보내주세요!<br>" +
@@ -13,5 +14,6 @@ import java.util.List;
 public class VotePlaceRequest {
     @Schema(description = "투표한 장소값 리스트")
     @NotNull(message = "투표하기위한 장소를 보내주세요.")
-    private List<Long> currentVotePlaceSlotIds;
+    private Set<Long> currentVotePlaceSlotIds;
+
 }

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/PlaceSlotReader.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/PlaceSlotReader.java
@@ -7,6 +7,7 @@ import com.prography.yakgwa.global.meta.ImplService;
 import lombok.RequiredArgsConstructor;
 
 import java.util.List;
+import java.util.Set;
 
 @ImplService
 @RequiredArgsConstructor
@@ -17,16 +18,15 @@ public class PlaceSlotReader {
         return repository.findAllByMeetId(meetId);
     }
 
-    public PlaceSlot readConfirmOrNullByMeetId(Long meetId) {
-        return repository.findConfirmByMeetId(meetId)
-                .orElse(null);
+    public List<PlaceSlot> readAllConfirmByMeetId(Long meetId) {
+        return repository.findConfirmByMeetId(meetId);
     }
 
     public boolean existConfirm(Long meetId) {
         return repository.existsByMeetId(meetId);
     }
 
-    public List<PlaceSlot> findAllByIds(List<Long> ids) {
+    public List<PlaceSlot> findAllByIds(Set<Long> ids) {
         return repository.findAllById(ids);
     }
 

--- a/src/main/java/com/prography/yakgwa/domain/vote/impl/TimeSlotReader.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/impl/TimeSlotReader.java
@@ -14,10 +14,6 @@ import java.util.List;
 public class TimeSlotReader {
     private final TimeSlotJpaRepository repository;
 
-    public List<TimeSlot> readByMeetId(Long meetId) {
-        return repository.findByMeetId(meetId);
-    }
-
     public List<TimeSlot> readAllByMeetId(Long meetId) {
         return repository.findAllByMeetId(meetId);
     }
@@ -27,9 +23,8 @@ public class TimeSlotReader {
      * Write-Date) 2024-07-12
      * Finish-Date) 2024-07-12
      */
-    public TimeSlot readConfirmOrNullByMeetId(Long meetId) {
-        return repository.findConfirmByMeetId(meetId)
-                .orElse(null);
+    public List<TimeSlot> readAllConfirmByMeetId(Long meetId) {
+        return repository.findAllConfirmByMeetId(meetId);
     }
 
     public boolean existConfirm(Long meetId) {

--- a/src/main/java/com/prography/yakgwa/domain/vote/repository/PlaceSlotJpaRepository.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/repository/PlaceSlotJpaRepository.java
@@ -15,7 +15,7 @@ public interface PlaceSlotJpaRepository extends JpaRepository<PlaceSlot, Long> {
     List<PlaceSlot> findAllByMeetId(@Param("meetId") Long meetId);
 
     @Query("SELECT PS FROM PLACESLOT_TABLE PS WHERE PS.meet.id = :meetId AND PS.confirm = true")
-    Optional<PlaceSlot> findConfirmByMeetId(@Param("meetId") Long meetId);
+    List<PlaceSlot> findConfirmByMeetId(@Param("meetId") Long meetId);
 
     @Query("select count(*)>0 from PLACESLOT_TABLE as ps where ps.confirm=true and ps.meet.id=:meetId")
     boolean existsByMeetId(@Param("meetId") Long meetId);

--- a/src/main/java/com/prography/yakgwa/domain/vote/repository/TimeSlotJpaRepository.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/repository/TimeSlotJpaRepository.java
@@ -17,7 +17,7 @@ public interface TimeSlotJpaRepository extends JpaRepository<TimeSlot, Long> {
     List<TimeSlot> findAllByMeetId(Long meetId);
 
     @Query("SELECT TS FROM TIMESLOT_TABLE TS WHERE TS.meet.id = :meetId AND TS.confirm = true")
-    Optional<TimeSlot> findConfirmByMeetId(@Param("meetId") Long meetId);
+    List<TimeSlot> findAllConfirmByMeetId(@Param("meetId") Long meetId);
 
     @Query("select count(*)>0 from TIMESLOT_TABLE as ts where ts.confirm=true and ts.meet.id=:meetId")
     boolean existsByMeetId(@Param("meetId") Long meetId);

--- a/src/main/java/com/prography/yakgwa/domain/vote/service/req/EnableTimeRequestDto.java
+++ b/src/main/java/com/prography/yakgwa/domain/vote/service/req/EnableTimeRequestDto.java
@@ -5,9 +5,10 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Builder
 public class EnableTimeRequestDto {
-    private List<LocalDateTime> enableTimes;
+    private Set<LocalDateTime> enableTimes;
 }

--- a/src/main/java/com/prography/yakgwa/global/format/exception/param/DataIntegrateException.java
+++ b/src/main/java/com/prography/yakgwa/global/format/exception/param/DataIntegrateException.java
@@ -3,16 +3,17 @@ package com.prography.yakgwa.global.format.exception.param;
 import com.prography.yakgwa.global.format.exception.ApplicationRunException;
 import com.prography.yakgwa.global.format.exception.ErrorEnumCode;
 
+import static com.prography.yakgwa.global.format.exception.param.errorCode.ParamErrorCode.DATA_INTEGRATE_EXCEPTION;
 import static com.prography.yakgwa.global.format.exception.param.errorCode.ParamErrorCode.MULTIPART_PARAMETER_EXCEPTION;
 
-public class MultipartParamException extends ApplicationRunException {
-    private static final ErrorEnumCode CODE = MULTIPART_PARAMETER_EXCEPTION;
+public class DataIntegrateException extends ApplicationRunException {
+    private static final ErrorEnumCode CODE = DATA_INTEGRATE_EXCEPTION;
 
-    private MultipartParamException(ErrorEnumCode CODE) {
+    private DataIntegrateException(ErrorEnumCode CODE) {
         super(CODE);
     }
 
-    public MultipartParamException() {
+    public DataIntegrateException() {
         this(CODE);
     }
 }

--- a/src/main/java/com/prography/yakgwa/global/format/exception/param/TimeParamException.java
+++ b/src/main/java/com/prography/yakgwa/global/format/exception/param/TimeParamException.java
@@ -3,7 +3,7 @@ package com.prography.yakgwa.global.format.exception.param;
 import com.prography.yakgwa.global.format.exception.ApplicationRunException;
 import com.prography.yakgwa.global.format.exception.ErrorEnumCode;
 
-import static com.prography.yakgwa.global.format.exception.param.errorCode.MeetErrorCode.TIME_PARAM_EXCEPTION;
+import static com.prography.yakgwa.global.format.exception.param.errorCode.ParamErrorCode.TIME_PARAM_EXCEPTION;
 
 public class TimeParamException extends ApplicationRunException {
     private static final ErrorEnumCode CODE = TIME_PARAM_EXCEPTION;

--- a/src/main/java/com/prography/yakgwa/global/format/exception/param/errorCode/ParamErrorCode.java
+++ b/src/main/java/com/prography/yakgwa/global/format/exception/param/errorCode/ParamErrorCode.java
@@ -6,9 +6,10 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public enum MeetErrorCode implements ErrorEnumCode {
+public enum ParamErrorCode implements ErrorEnumCode {
     TIME_PARAM_EXCEPTION("PE001", "모임 확정시간과 투표기간은 동시에 입력 또는 제외될수없습니다. 파라미터를 확인해주세요."),
-    MULTIPART_PARAMETER_EXCEPTION("PE002","사진 파라미터를 확인해주세요.");
+    MULTIPART_PARAMETER_EXCEPTION("PE002","사진 파라미터를 확인해주세요."),
+    DATA_INTEGRATE_EXCEPTION("PE003","데이터정합문제입니다. 개발자에게 문의주세요");
     private final String code;
     private final String message;
 }

--- a/src/test/java/com/prography/yakgwa/domain/vote/controller/req/EnableTimeRequestTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/vote/controller/req/EnableTimeRequestTest.java
@@ -1,0 +1,29 @@
+package com.prography.yakgwa.domain.vote.controller.req;
+
+import com.prography.yakgwa.domain.vote.service.req.EnableTimeRequestDto;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class EnableTimeRequestTest {
+    @Test
+    void dto로변환시set으로중복시간삭제하는테스트() {
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        List<LocalDateTime> times = List.of(now, now, now, now);
+        EnableTimeRequest enableTimeRequest = EnableTimeRequest.of(times);
+        // when
+        System.out.println("=====Logic Start=====");
+
+        EnableTimeRequestDto requestDto = enableTimeRequest.toRequestDto();
+
+        System.out.println("=====Logic End=====");
+        // then
+        assertThat(requestDto.getEnableTimes().size()).isEqualTo(1);
+
+    }
+}

--- a/src/test/java/com/prography/yakgwa/domain/vote/impl/TimeSlotReaderTest.java
+++ b/src/test/java/com/prography/yakgwa/domain/vote/impl/TimeSlotReaderTest.java
@@ -9,7 +9,6 @@ import com.prography.yakgwa.domain.user.entity.User;
 import com.prography.yakgwa.domain.user.repository.UserJpaRepository;
 import com.prography.yakgwa.domain.vote.entity.time.TimeSlot;
 import com.prography.yakgwa.domain.vote.repository.TimeSlotJpaRepository;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,9 +18,9 @@ import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 import static com.prography.yakgwa.domain.user.entity.AuthType.KAKAO;
-import static org.assertj.core.api.Assertions.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -65,13 +64,11 @@ class TimeSlotReaderTest {
         // when
         System.out.println("=====Logic Start=====");
 
-        TimeSlot timeSlot = timeSlotReader.readConfirmOrNullByMeetId(saveMeet.getId());
+        List<TimeSlot> timeSlot = timeSlotReader.readAllConfirmByMeetId(saveMeet.getId());
 
         System.out.println("=====Logic End=====");
         // then
-        assertAll(() -> assertThat(timeSlot).isNotNull(),
-                () -> assertThat(timeSlot.getId()).isEqualTo(saveTimeSlot.getId())
-                , () -> assertThat(timeSlot.getTime()).isEqualTo(time));
+        assertAll(() -> assertThat(timeSlot.size()).isOne());
     }
 
     @Test
@@ -91,11 +88,11 @@ class TimeSlotReaderTest {
         // when
         System.out.println("=====Logic Start=====");
 
-        TimeSlot timeSlot = timeSlotReader.readConfirmOrNullByMeetId(saveMeet.getId());
+        List<TimeSlot> timeSlot = timeSlotReader.readAllConfirmByMeetId(saveMeet.getId());
 
         System.out.println("=====Logic End=====");
         // then
-        assertAll(() -> assertThat(timeSlot).isNull());
+        assertAll(() -> assertThat(timeSlot.size()).isZero());
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #13 

---
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 투표 확정시 확정여부 검사를 안해 중복으로 데이터가 들어가는 문제 발생
- 예외처리하였고, 확정된 조회를 할때 List로 변경한후 정합문제 발생시 예외나오도록 수정 

### 스크린샷 (선택)


---