### PR TITLE
fix:  taskScheduler에 같은 key로 여러개 등록되는 버그 수정

### DIFF
--- a/src/main/java/com/prography/yakgwa/domain/common/schedule/ScheduleRegister.java
+++ b/src/main/java/com/prography/yakgwa/domain/common/schedule/ScheduleRegister.java
@@ -19,7 +19,6 @@ import java.util.concurrent.ScheduledFuture;
 public class ScheduleRegister {
     private final TaskScheduler taskScheduler;
     private final ConcurrentHashMap<String, ScheduledFuture<?>> scheduleMap = new ConcurrentHashMap<>();
-//    private final ConcurrentHashMap<ScheduledFuture<?>, Runnable> taskMap = new ConcurrentHashMap<>();
     public static final String MEET_ALARM_FORMAT = "MeetAlarm_%s: %d";
 
     public void scheduleTask(Meet meet, AlarmType type, Runnable task, LocalDateTime time) {

--- a/src/main/java/com/prography/yakgwa/global/runner/AlarmRunner.java
+++ b/src/main/java/com/prography/yakgwa/global/runner/AlarmRunner.java
@@ -25,8 +25,7 @@ public class AlarmRunner implements ApplicationRunner {
         log.info("AlarmRunner: 알람등록진행");
         all.stream()
                 .filter(alarm -> !alarm.isSend())
-                .forEach(alarm ->
-                        alarmScheduler.registerAlarm(alarm.getMeet(), alarm.getAlarmType()));
+                .forEach(alarm -> alarmScheduler.regist(alarm.getMeet(), alarm.getAlarmType()));
         log.info("AlarmRunner: 알람등록완료");
     }
 }


### PR DESCRIPTION
- registerAlarm을 그대로 재사용하여 Alarm이 DB에 중복저장되어 같은 key의 작업이 여러개 등록됌

## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
- #90 

---
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 애플리케이션 재실행시 작업 등록될때 registerAlarm메서드를 그대로 사용하여 DB에 같은 Alarm을 여러개 등록하게 되고, 하나의 Key만 가져야하는 taskScheduler에서 버그가 일어남

### 스크린샷 (선택)


---